### PR TITLE
Better locking error recovery

### DIFF
--- a/.nova/Tasks/Dev.json
+++ b/.nova/Tasks/Dev.json
@@ -14,5 +14,6 @@
     }
   },
   "identifier": "3735023F-0F79-4B2D-8EC9-DAE3ABF0A9EF",
-  "openLogOnRun": "fail"
+  "openLogOnRun": "fail",
+  "persistent": true
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## future
+
+### Fixed
+
+- Better dependency management locking error recovery
+
 ## v1.2.1
 
 - Fix bad publish

--- a/src/dependencyManagement.ts
+++ b/src/dependencyManagement.ts
@@ -1,3 +1,8 @@
+async function clearLock() {
+  const lockFilePath = nova.path.join(getDependencyDirectory(), "LOCK");
+  nova.fs.remove(lockFilePath);
+}
+
 export function registerDependencyUnlockCommand(command: string) {
   nova.commands.register(command, clearLock);
 }
@@ -9,11 +14,6 @@ export function getDependencyDirectory(): string {
     nova.extension.globalStoragePath,
     "dependencyManagement"
   );
-}
-
-async function clearLock() {
-  const lockFilePath = nova.path.join(getDependencyDirectory(), "LOCK");
-  nova.fs.remove(lockFilePath);
 }
 
 // https://github.com/es-shims/String.prototype.trimEnd/blob/master/implementation.js

--- a/src/dependencyManagement.ts
+++ b/src/dependencyManagement.ts
@@ -28,26 +28,26 @@ interface InstallationOptions {
   console?: Partial<Console> | null;
 }
 
+const boundGlobalConsole: typeof console = {
+  assert: console.assert.bind(console),
+  clear: console.clear.bind(console),
+  log: console.log.bind(console),
+  info: console.info.bind(console),
+  warn: console.warn.bind(console),
+  error: console.error.bind(console),
+  group: console.group.bind(console),
+  groupEnd: console.groupEnd.bind(console),
+  count: console.count.bind(console),
+  time: console.time.bind(console),
+  timeEnd: console.timeEnd.bind(console),
+  timeStamp: console.timeStamp?.bind(console),
+  trace: console.trace.bind(console),
+};
+
 export async function installWrappedDependencies(
   compositeDisposable: CompositeDisposable,
   options: InstallationOptions = {}
 ) {
-  const boundGlobalConsole: typeof console = {
-    assert: console.assert.bind(console),
-    clear: console.clear.bind(console),
-    log: console.log.bind(console),
-    info: console.info.bind(console),
-    warn: console.warn.bind(console),
-    error: console.error.bind(console),
-    group: console.group.bind(console),
-    groupEnd: console.groupEnd.bind(console),
-    count: console.count.bind(console),
-    time: console.time.bind(console),
-    timeEnd: console.timeEnd.bind(console),
-    timeStamp: console.timeStamp?.bind(console),
-    trace: console.trace.bind(console),
-  };
-
   const logger =
     options.console === null
       ? null

--- a/src/dependencyManagement.ts
+++ b/src/dependencyManagement.ts
@@ -1,8 +1,3 @@
-async function clearLock() {
-  const lockFilePath = nova.path.join(getDependencyDirectory(), "LOCK");
-  nova.fs.remove(lockFilePath);
-}
-
 export function registerDependencyUnlockCommand(command: string) {
   nova.commands.register(command, clearLock);
 }
@@ -16,6 +11,11 @@ export function getDependencyDirectory(): string {
   );
 }
 
+async function clearLock() {
+  const lockFilePath = nova.path.join(getDependencyDirectory(), "LOCK");
+  nova.fs.remove(lockFilePath);
+}
+
 // https://github.com/es-shims/String.prototype.trimEnd/blob/master/implementation.js
 // eslint-disable-next-line no-control-regex
 const endWhitespace = /[\x09\x0A\x0B\x0C\x0D\x20\xA0\u1680\u180E\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200A\u202F\u205F\u3000\u2028\u2029\uFEFF]*$/;
@@ -24,8 +24,19 @@ function trimRight(str: string) {
   return str.replace(endWhitespace, "");
 }
 
+const fiveMinutes = 5 * 60 * 1000;
+const lockCheckInterval = 500;
+
 interface InstallationOptions {
   console?: Partial<Console> | null;
+}
+
+async function asyncSetTimeout(cb: () => void, time: number) {
+  await new Promise((resolve) =>
+    setTimeout(() => {
+      resolve(cb());
+    }, time)
+  );
 }
 
 const boundGlobalConsole: typeof console = {
@@ -53,8 +64,6 @@ export async function installWrappedDependencies(
       ? null
       : Object.assign({}, boundGlobalConsole, options.console);
 
-  const dependencyDirectory = getDependencyDirectory();
-
   function copyForInstall(file: string) {
     try {
       const src = nova.path.join(nova.extension.path, file);
@@ -67,6 +76,8 @@ export async function installWrappedDependencies(
       logger?.warn(err);
     }
   }
+
+  const dependencyDirectory = getDependencyDirectory();
 
   nova.fs.mkdir(dependencyDirectory);
 
@@ -81,17 +92,68 @@ export async function installWrappedDependencies(
   } catch (err) {
     logger?.log("already locked");
     // expected error if file is already present, aka a lock has been acquired
-    // wait until it's gone. That indicates another workspace has completed the install
-    // note: can't use file watcher here since it's workspace relative
-    return new Promise((resolve) =>
-      setInterval(() => {
-        if (!nova.fs.access(lockFilePath, nova.fs.constants.F_OK)) {
-          resolve();
-        }
-      }, 500)
-    );
+    // wait until it's unlocked (another workspace completed install)
+    try {
+      await asyncSetTimeout(waitUntilUnlocked, lockCheckInterval);
+      logger?.log("unlocked cleanly");
+    } catch (err) {
+      logger?.warn("unlocked", (err as Error).message);
+      console.log(err);
+      clearLock();
+      // recurse
+      await installWrappedDependencies(compositeDisposable, options);
+    }
+    return;
   }
-  lockFile.close();
+
+  // three main methods
+  // * happy path - lock file cleared
+  // * install crashes without clearing lockfile - I'm a little worried about race conditions with this one, but it'll be graceful
+  // * lockfile expires
+  async function waitUntilUnlocked() {
+    // Expected unlock path - lock file is removed
+    // note: can't use file watcher here since it's workspace relative
+    if (!nova.fs.access(lockFilePath, nova.fs.constants.F_OK)) {
+      return;
+    }
+
+    const lockFile = nova.fs.open(lockFilePath) as FileTextMode;
+    const pid = lockFile.read();
+    lockFile.close();
+    // once the install process starts running, the lockfile will be hold its PID
+    // if it's not running any more, Nova's extension service might have crashed without clearing the lockfile
+    // unfortunately, since the process isn't started atomically there's a gap between lock acquisition and
+    // process starting, so this won't work if the crash happened early on
+    if (pid) {
+      const pidRunning = await new Promise<boolean>((resolve, reject) => {
+        const process = new Process("/usr/bin/env", {
+          args: ["ps", "-p", pid],
+          stdio: "ignore",
+        });
+        process.onDidExit((status) => resolve(status == 0));
+        compositeDisposable.add({
+          dispose() {
+            clearLock();
+            process.terminate();
+reject(new Error("ps cancelled by disposable"));
+          },
+        });
+        process.start();
+      });
+      if (!pidRunning) {
+        throw new Error("install process not running");
+      }
+    }
+
+    // this shouldn't take forever, if it times out kill everything and start over?
+    const stats = nova.fs.stat(lockFilePath);
+    if (stats && new Date().getTime() - stats.mtime.getTime() > fiveMinutes) {
+      throw new Error("lockfile is too old");
+    }
+
+    // try again
+    await asyncSetTimeout(waitUntilUnlocked, lockCheckInterval);
+  }
 
   let done = false;
 
@@ -126,12 +188,18 @@ export async function installWrappedDependencies(
           if (!done) {
             clearLock();
             process.terminate();
+            reject(new Error("install cancelled by disposable"));
+          } else {
+            resolve();
           }
         },
       });
       process.start();
+      lockFile.write(String(process.pid));
+      lockFile.close();
     });
   } finally {
+    logger?.log("clearing lock");
     clearLock();
     done = true;
   }

--- a/src/dependencyManagement.ts
+++ b/src/dependencyManagement.ts
@@ -98,7 +98,6 @@ export async function installWrappedDependencies(
       logger?.log("unlocked cleanly");
     } catch (err) {
       logger?.warn("unlocked", (err as Error).message);
-      console.log(err);
       clearLock();
       // recurse
       await installWrappedDependencies(compositeDisposable, options);
@@ -135,7 +134,7 @@ export async function installWrappedDependencies(
           dispose() {
             clearLock();
             process.terminate();
-reject(new Error("ps cancelled by disposable"));
+            reject(new Error("ps cancelled by disposable"));
           },
         });
         process.start();


### PR DESCRIPTION
This applies both suggestions from #8 - recovery from a crashed install process due to the extension crashing by tracking it's PID, and detecting an old lock file.

This ends up getting a little complicated because the install process is not atomically created or torn down with locking/unlocking (there's file copying first). Additionally, introducing the process to check that the other process is running introduces a _second_ process. I decided not to add the same pid locking to that one since it should be a very fast check, and I'd have to clear the lock file before rewriting to it.

A follow up could be attempting to implement the full install (including copying) as an external process.